### PR TITLE
chore: update dependencies to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "@cerbos/grpc": "^0.27.0",
-        "@workos-inc/node": "^8.0.0",
-        "dotenv": "^16.0.0",
-        "express": "^5.0.0",
-        "express-session": "^1.17.2",
-        "morgan": "^1.10.0",
-        "pug": "^3.0.2"
+        "@cerbos/grpc": "^0.27.1",
+        "@workos-inc/node": "^10.7.0",
+        "dotenv": "^17.4.2",
+        "express": "^5.2.1",
+        "express-session": "^1.19.0",
+        "morgan": "^1.11.0",
+        "pug": "^3.0.4"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
@@ -48,12 +48,14 @@
     "node_modules/@bufbuild/protobuf": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
-      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA=="
+      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "peer": true
     },
     "node_modules/@cerbos/api": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@cerbos/api/-/api-0.8.0.tgz",
       "integrity": "sha512-iVEdsoYax/gKchx8jv60yNv48HzXfVC/1//f6U4mo5PrGt8k28Nbb95RM4R2U7eT0p3uqDUC8PSovTIrdA6Xww==",
+      "peer": true,
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0"
       },
@@ -195,14 +197,12 @@
       }
     },
     "node_modules/@workos-inc/node": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@workos-inc/node/-/node-8.13.0.tgz",
-      "integrity": "sha512-NgQKHpwh8AbT4KvAsW91Y+4f4jja2IvFPQ5atcy5NUxUMVRgXzRFEee3erawfXrTmiCVqJjd9PljHySKBXmHKQ==",
-      "dependencies": {
-        "eventemitter3": "^5.0.4"
-      },
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/@workos-inc/node/-/node-10.7.0.tgz",
+      "integrity": "sha512-rffa9znZuIv4yo+9JRxGOLTTSxh0XhOT6jlsktgqEi9MuB9V0VFHRzLd3bTpkq+J9sgrPZNGpvX4aWNfMqt5cQ==",
+      "license": "MIT",
       "engines": {
-        "node": ">=20.15.0"
+        "node": ">=22.11.0"
       }
     },
     "node_modules/accepts": {
@@ -496,9 +496,10 @@
       "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk="
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -584,11 +585,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="
     },
     "node_modules/express": {
       "version": "5.2.1",
@@ -1782,12 +1778,14 @@
     "@bufbuild/protobuf": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
-      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA=="
+      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "peer": true
     },
     "@cerbos/api": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@cerbos/api/-/api-0.8.0.tgz",
       "integrity": "sha512-iVEdsoYax/gKchx8jv60yNv48HzXfVC/1//f6U4mo5PrGt8k28Nbb95RM4R2U7eT0p3uqDUC8PSovTIrdA6Xww==",
+      "peer": true,
       "requires": {
         "@bufbuild/protobuf": "^2.12.0"
       }
@@ -1898,12 +1896,9 @@
       }
     },
     "@workos-inc/node": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@workos-inc/node/-/node-8.13.0.tgz",
-      "integrity": "sha512-NgQKHpwh8AbT4KvAsW91Y+4f4jja2IvFPQ5atcy5NUxUMVRgXzRFEee3erawfXrTmiCVqJjd9PljHySKBXmHKQ==",
-      "requires": {
-        "eventemitter3": "^5.0.4"
-      }
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/@workos-inc/node/-/node-10.7.0.tgz",
+      "integrity": "sha512-rffa9znZuIv4yo+9JRxGOLTTSxh0XhOT6jlsktgqEi9MuB9V0VFHRzLd3bTpkq+J9sgrPZNGpvX4aWNfMqt5cQ=="
     },
     "accepts": {
       "version": "2.0.0",
@@ -2113,9 +2108,9 @@
       "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk="
     },
     "dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="
     },
     "dunder-proto": {
       "version": "1.0.1",
@@ -2174,11 +2169,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
-    },
-    "eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="
     },
     "express": {
       "version": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
-    "@cerbos/grpc": "^0.27.0",
-    "@workos-inc/node": "^8.0.0",
-    "dotenv": "^16.0.0",
-    "express": "^5.0.0",
-    "express-session": "^1.17.2",
-    "morgan": "^1.10.0",
-    "pug": "^3.0.2"
+    "@cerbos/grpc": "^0.27.1",
+    "@workos-inc/node": "^10.7.0",
+    "dotenv": "^17.4.2",
+    "express": "^5.2.1",
+    "express-session": "^1.19.0",
+    "morgan": "^1.11.0",
+    "pug": "^3.0.4"
   }
 }


### PR DESCRIPTION
## Dependency updates

Bumps all dependencies to their latest versions (including major upgrades).

### Version bumps
| Package | From | To |
|---|---|---|
| `@workos-inc/node` | ^8.0.0 | ^10.7.0 (major x2) |
| `dotenv` | ^16.0.0 | ^17.4.2 (major) |
| `express` | ^5.0.0 | ^5.2.1 |
| `express-session` | ^1.17.2 | ^1.19.0 |
| `morgan` | ^1.10.0 | ^1.11.0 |
| `@cerbos/grpc` | ^0.27.0 | ^0.27.1 |
| `pug` | ^3.0.2 | ^3.0.4 |

### Notable majors
- **@workos-inc/node 8 -> 10**: package is now ESM-first (`"type": "module"`) but still ships a CJS build, so the existing `require()` usage keeps working. The APIs used by this app — `userManagement.getAuthorizationUrl()` and `userManagement.authenticateWithCode()` — retain the same signatures and return shapes. No code changes required.
- **dotenv 16 -> 17**: `dotenv.config()` unchanged; env loads correctly.

### Breaking-change fixes
None required — all touched APIs are source-compatible.

### Verification
- No lint/test/build scripts defined in package.json.
- Smoke test: booted `node index.js`, `GET /` -> 200 (pug render), `GET /auth` -> 302 (WorkOS AuthKit redirect). All modules load and the WorkOS auth-URL builder produces a valid URL.

Note: `npm audit` reports transitive advisories; these are not top-level deps and are out of scope for this latest-version bump.